### PR TITLE
Security Fix - Command Injection - Replace `os.system` with `subprocess.call`

### DIFF
--- a/VirtualStage/BackgroundMatting/fixed_threshold.py
+++ b/VirtualStage/BackgroundMatting/fixed_threshold.py
@@ -1,8 +1,11 @@
 import os
 
+from helpers import spawn
+
 
 def fixed_split(videos, thresholds, mask_suffix, overlap=0):
     print(f"Splitting {len(videos)} videos vertically by a fixed threshold")
+    log_file = open("split_logs.txt", 'w')
 
     for i, video in enumerate(videos):
         if i >= (len(thresholds)) or not thresholds[i]:
@@ -19,54 +22,91 @@ def fixed_split(videos, thresholds, mask_suffix, overlap=0):
         idw_region = f"iw:ih-{threshold}+{overlap}:0:{threshold - overlap}"
 
         # crop color images
-        code = os.system(
-            f"ffmpeg -i {os.path.join(video, '%04d_img.png')} "
-            f'-filter:v "crop={iup_region}" '
-            f"{os.path.join(video+'_up', '%04d_img.png')}"
-            " > split_logs.txt 2>&1"
+        code = spawn(
+            [
+                "ffmpeg",
+                "-i",
+                f"{os.path.join(video, '%04d_img.png')}",
+                "-filter:v",
+                f"crop={iup_region}",
+                f"{os.path.join(video+'_up', '%04d_img.png')}",
+            ],
+            stdout=log_file,
+            stderr=log_file,
         )
         if code != 0:
             exit(code)
-        code = os.system(
-            f"ffmpeg -i {os.path.join(video, '%04d_img.png')} "
-            f'-filter:v "crop={idw_region}" '
-            f"{os.path.join(video+'_dw', '%04d_img.png')}"
-            " > split_logs.txt 2>&1"
+        code = spawn(
+            [
+                "ffmpeg",
+                "-i",
+                f"{os.path.join(video, '%04d_img.png')}",
+                '-filter:v',
+                f"crop={idw_region}",
+                f"{os.path.join(video+'_dw', '%04d_img.png')}",
+            ],
+            stdout=log_file,
+            stderr=log_file,
         )
         if code != 0:
             exit(code)
 
         # crop mask images
-        code = os.system(
-            f"ffmpeg -i {os.path.join(video, '%04d')}{mask_suffix}.png "
-            f'-filter:v "crop={iup_region}" '
-            f"{os.path.join(video+'_up', '%04d')}{mask_suffix}.png"
-            " > split_logs.txt 2>&1"
+        code = spawn(
+            [
+                "ffmpeg",
+                "-i",
+                f"{os.path.join(video, '%04d')}{mask_suffix}.png",
+                '-filter:v',
+                f"crop={iup_region}",
+                f"{os.path.join(video+'_up', '%04d')}{mask_suffix}.png",
+            ],
+            stdout=log_file,
+            stderr=log_file,
         )
         if code != 0:
             exit(code)
-        code = os.system(
-            f"ffmpeg -i {os.path.join(video, '%04d')}{mask_suffix}.png "
-            f'-filter:v "crop={idw_region}" '
-            f"{os.path.join(video+'_dw', '%04d')}{mask_suffix}.png"
-            " > split_logs.txt 2>&1"
+        code = spawn(
+            [
+                "ffmpeg",
+                "-i",
+                f"{os.path.join(video, '%04d')}{mask_suffix}.png",
+                '-filter:v',
+                f"crop={idw_region}",
+                f"{os.path.join(video+'_dw', '%04d')}{mask_suffix}.png",
+            ],
+            stdout=log_file,
+            stderr=log_file,
         )
         if code != 0:
             exit(code)
 
         # crop background image
-        code = os.system(
-            f"ffmpeg -y -i {video+'.png'} "
-            f"-filter:v \"crop={iup_region}\" {video+'_up.png'}"
-            " > split_logs.txt 2>&1"
+        code = spawn(
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                f"{video+'.png'}",
+                f"-filter:v \"crop={iup_region}\" {video+'_up.png'}",
+            ],
+            stdout=log_file,
+            stderr=log_file,
         )
         if code != 0:
             exit(code)
-        code = os.system(
-            f"ffmpeg -y -i {video+'.png'} "
-            f'-filter:v "crop={idw_region}" '
-            f"{video+'_dw.png'}"
-            " > split_logs.txt 2>&1"
+        code = spawn(
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                f"{video+'.png'}",
+                '-filter:v',
+                f"crop={idw_region}",
+                f"{video+'_dw.png'}",
+            ],
+            stdout=log_file,
+            stderr=log_file,
         )
         if code != 0:
             exit(code)
@@ -76,12 +116,15 @@ def fixed_split(videos, thresholds, mask_suffix, overlap=0):
 
 def fixed_merge(videos, factors, output_dir, suffix, outputs_list, overlap=0):
     print(f"Reconstructing {len(videos)} output images")
+    log_file = open("merge_logs.txt", 'w')
+
     for i, video in enumerate(videos):
         if i < (len(factors)) and factors[i]:
             # video split, merging
-            out_path = os.path.join(output_dir, os.path.basename(video)).replace(
-                "\\", "/"
-            )
+            out_path = os.path.join(
+                output_dir,
+                os.path.basename(video),
+            ).replace("\\", "/")
 
             try:
                 os.makedirs(out_path + suffix)
@@ -92,13 +135,20 @@ def fixed_merge(videos, factors, output_dir, suffix, outputs_list, overlap=0):
             outpdw = (out_path + "_dw" + suffix).replace("\\", "/")
 
             for o in outputs_list:
-                code = os.system(
-                    f"ffmpeg -i {outpup}/%04d_{o}.png -i {outpdw}/%04d_{o}.png "
-                    f'-filter_complex "[0:0]crop=iw:ih-{overlap}:0:0[v0];'
-                    f"[1:0]crop=iw:ih-{overlap}:0:{overlap}[v1];"
-                    f'[v0][v1]vstack" '
-                    f"{out_path + suffix}/%04d_{o}.png -hide_banner"
-                    " > merge_logs.txt"
+                code = spawn(
+                    [
+                        "ffmpeg",
+                        "-i",
+                        f"{outpup}/%04d_{o}.png",
+                        "-i",
+                        f"{outpdw}/%04d_{o}.png",
+                        '-filter_complex',
+                        f"[0:0]crop=iw:ih-{overlap}:0:0[v0];[1:0]crop=iw:ih-{overlap}:0:{overlap}[v1];[v0][v1]vstack",
+                        f"{out_path + suffix}/%04d_{o}.png",
+                        "-hide_banner",
+                    ],
+                    stdout=log_file,
+                    stderr=log_file,
                 )
                 if code != 0:
                     exit(code)

--- a/VirtualStage/BackgroundMatting/helpers.py
+++ b/VirtualStage/BackgroundMatting/helpers.py
@@ -1,0 +1,11 @@
+"""
+Helper functions to ease dev burden.
+"""
+import subprocess
+
+
+def spawn(args, **kwargs):
+    """
+    Executes an OS command, waits for it to complete, returns exit code.
+    """
+    return subprocess.call(args, **kwargs)

--- a/VirtualStage/BackgroundMatting/prepare_data.py
+++ b/VirtualStage/BackgroundMatting/prepare_data.py
@@ -1,12 +1,21 @@
 import os
 
+from helpers import spawn
+
 
 def prepare_videos(
-    videos, extension, start, duration, kinect_mask=True, width=1920, height=1080
+    videos,
+    extension,
+    start,
+    duration,
+    kinect_mask=True,
+    width=1920,
+    height=1080,
 ):
     video_start_secs = start % 60
     video_start_mins = start // 60
     print(f"Dumping frames and segmenting {len(videos)} input videos")
+    log_file = open("bg_matting_logs.txt", "w")
     for i, video in enumerate(videos):
         try:
             os.makedirs(video)
@@ -14,40 +23,83 @@ def prepare_videos(
             continue
 
         print(f"Dumping frames from {video} ({i+1}/{len(videos)})...")
+        segmentation_log = open(f"segmentation_logs_{i}.txt", "w")
         ffmpeg_duration = ""
         if duration != "-1":
             ffmpeg_duration = f"-t {duration}"
-        code = os.system(
-            f"ffmpeg -y -ss 00:{video_start_mins:02}:{video_start_secs:02}.000 "
-            f"-vsync 0 "
-            f"-i {video}{extension} -vf scale={width}:{height} "
-            f"-map 0:0 {ffmpeg_duration} {video}/%04d_img.png -hide_banner"
-            f" > bg_matting_logs.txt 2>&1"
+        code = spawn(
+            [
+                "ffmpeg",
+                "-y",
+                "-ss",
+                f"00:{video_start_mins:02}:{video_start_secs:02}.000",
+                "-vsync",
+                "0",
+                "-i",
+                f"{video}{extension}",
+                "-vf",
+                f"scale={width}:{height}",
+                "-map",
+                "0:0",
+                f"{ffmpeg_duration}",
+                f"{video}/%04d_img.png",
+                "-hide_banner",
+            ],
+            stdout=log_file,
+            stderr=log_file,
         )
         if code != 0:
             exit(code)
 
         print(f"Segmenting frames...")
         if kinect_mask:
-            code = os.system(
-                f"KinectMaskGenerator.exe {video}{extension} {video} {start} {duration}"
-                f" > segmentation_logs_{i}.txt 2>&1"
+            code = spawn(
+                [
+                    "KinectMaskGenerator.exe",
+                    f"{video}{extension}",
+                    f"{video}",
+                    f"{start}",
+                    f"{duration}",
+                ],
+                stdout=segmentation_log,
+                stderr=segmentation_log,
             )
             if code != 0:
                 exit(code)
         else:
-            code = os.system(
-                f"python segmentation_deeplab.py -i {video}"
-                f" > segmentation_logs_{i}.txt 2>&1"
+            code = spawn(
+                [
+                    "python",
+                    "segmentation_deeplab.py",
+                    "-i",
+                    f"{video}",
+                ],
+                stdout=segmentation_log,
+                stderr=segmentation_log,
             )
             if code != 0:
                 exit(code)
 
         print(f"Extracting background...")
-        code = os.system(
-            f"ffmpeg -y -i {video}{extension} -vf scale={width}:{height} "
-            f"-map 0:0 -ss 00:00:02.000 -vframes 1 {video}.png -hide_banner"
-            " > bg_matting_logs.txt 2>&1"
+        code = spawn(
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                f"{video}{extension}",
+                "-vf",
+                f"scale={width}:{height}",
+                "-map",
+                "0:0",
+                "-ss",
+                "00:00:02.000",
+                "-vframes",
+                "1",
+                f"{video}.png",
+                "-hide_banner",
+            ],
+            stdout=log_file,
+            stderr=log_file,
         )
         if code != 0:
             exit(code)


### PR DESCRIPTION
### 📊 Metadata *

AI Lab helps our large fast-growing community of developers get started on AI. You can experience, learn and code the latest and greatest innovations from Microsoft AI here. AI Lab currently houses eight projects that showcase the latest in custom vision, attnGAN, Visual Studio tools for AI, Cognitive Search, Machine Reading Comprehension and more. Each lab gives you access to the experimentation playground, source code on GitHub, a crisp developer-friendly video, and insights into the underlying developer/ organizational challenge and solution. AI Lab is developed in partnership with Microsoft’s AI School and the Microsoft Research (MSR) AI organization.

#### Bounty URL: https://huntr.dev/bounties/1-other-microsoft/ailab/

### ⚙️ Description *

Mitigating the arbitrary code execution by total reworking rather than using more library code for sanitising. subprocess module provides a level of safety from code execution vulnerabilities. Every call to `os.system` api is replaced by `subprocess.call` apis. `subprocess` module provides much more reliability for system command executions.

### 💻 Technical Description *

All references to `os.system` API calls are migrated to `subprocess.call` API, without using `shell=True`.

### 🐛 Proof of Concept (PoC) *

This POC is taken in an Ubuntu 20.04 LTS system.

1. Clone the repository from GitHub
2. Install the requirements using pip
3. For the sake of brevity, run the following commands,

```
//PoC.sh

touch '/tmp/;firefox;.mkv'
cd VirtualStage/BackgroundMatting/
python bg_matting.py -n test1 -i /tmp -o '/tmp/r' --fixed_threshold "640,"
```

4. POC image shows spawning a firefox instance by creating a file with malicious filename using ailab background matting script.
5. Disclosure POC [here](https://ibb.co/hLNMfzN).

### 🔥 Proof of Fix (PoF) *

Before:

![image](https://user-images.githubusercontent.com/64132745/116788698-ba41fd00-aac8-11eb-974e-14bef6e4933b.png)

After:

![image](https://user-images.githubusercontent.com/64132745/116788773-3a686280-aac9-11eb-981b-f5d4271a26dd.png)

### 👍 User Acceptance Testing (UAT)

After accommodating the changes, the functionality is unchanged.
